### PR TITLE
Add HTML validation tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
+require 'html-proofer'
+
 desc 'Test build, links on generated site'
 task :test do
   sh "bundle exec jekyll build"
+  HTMLProofer.check_directory("./_site", {
+    :allow_hash_href => true,
+    :check_html => true
+    }).run
 end
 
 task :default => [:test]
+


### PR DESCRIPTION
This PR restores HTMLProofer to the project (reverts 89a63a6, committed as part of PR #4).